### PR TITLE
Vending maching refills update

### DIFF
--- a/code/modules/cargo/packs/vendor_refill.dm
+++ b/code/modules/cargo/packs/vendor_refill.dm
@@ -48,22 +48,30 @@
 ///Pulsar 20/08/2024
 /datum/supply_pack/vendor_refill/mining
 	name = "Mining Equipement Supply Crate"
-	desc = "Improve your mining operations with this mining equipement supply crate."
+	desc = "Improve your mining operations with this mining equipement vending machine refill."
 	cost = 2500
 	contains = list(/obj/item/vending_refill/mining_equipment)
 	crate_name = "mining equipement crate"
 
 /datum/supply_pack/vendor_refill/medical
 	name = "Medical Supply Crate"
-	desc = "Keep yourself (and your crew) alive with this medical supply crate"
+	desc = "Keep yourself (and your crew) alive with this medical vending machine refill"
 	cost = 2500
 	contains = list(/obj/item/vending_refill/medical)
 	crate_name = "medical equipement crate"
 
 /datum/supply_pack/vendor_refill/engineering
-	name = "Engineering Supply Crate"
-	desc = "Start working on your machines properly with these engineering supply crates"
+	name = "Engineering Supply Crates"
+	desc = "Start working on your machines properly with these engineering vending machine refill"
 	cost = 3000
 	contains = list(/obj/item/vending_refill/engineering,
 					/obj/item/vending_refill/engivend)
 	crate_name = "engineering equipement crate"
+
+/datum/supply_pack/vendor_refill/hydroponics
+	name = "Hydroponics Supply Crates"
+	desc = "Got a green thumb ? This set of hydroponics vending machine refill will help you set up a neat little garden"
+	cost = 3000
+	contains = list(/obj/item/vending_refill/hydronutrients,
+					/obj/item/vending_refill/hydroseeds)
+	crate_name = "hydroponics equipement crate"

--- a/code/modules/cargo/packs/vendor_refill.dm
+++ b/code/modules/cargo/packs/vendor_refill.dm
@@ -44,3 +44,26 @@
 	cost = 1000
 	contains = list(/obj/item/vending_refill/games)
 	crate_name = "games supply crate"
+
+///Pulsar 20/08/2024
+/datum/supply_pack/vendor_refill/mining
+	name = "Mining Equipement Supply Crate"
+	desc = "Improve your mining operations with this mining equipement supply crate."
+	cost = 2500
+	contains = list(/obj/item/vending_refill/mining_equipment)
+	crate_name = "mining equipement crate"
+
+/datum/supply_pack/vendor_refill/medical
+	name = "Medical Supply Crate"
+	desc = "Keep yourself (and your crew) alive with this medical supply crate"
+	cost = 2500
+	contains = list(/obj/item/vending_refill/medical)
+	crate_name = "medical equipement crate"
+
+/datum/supply_pack/vendor_refill/engineering
+	name = "Engineering Supply Crate"
+	desc = "Start working on your machines properly with these engineering supply crates"
+	cost = 3000
+	contains = list(/obj/item/vending_refill/engineering,
+					/obj/item/vending_refill/engivend)
+	crate_name = "engineering equipement crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a Mining, Medical, Enginnering and Hydroponics vending machine refills to the outpost trading options.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives players an alternative to acquire such vending machines.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Mining, Medical, Enginnering and Hydroponics vending machine refills to the outpost trading options.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
